### PR TITLE
Added a few visualization options, and a verbose mode

### DIFF
--- a/caron/Caron.py
+++ b/caron/Caron.py
@@ -100,7 +100,5 @@ if __name__ == "__main__":
 
 """Todo:
 - Colormaps? Can they be defined also for log scale?
-  At that point one can operate the slider, and not before.
-  Clean the parsing (initial viz_fps not used anymore).
   Do not let anyone change the slider during calibration.
 """

--- a/caron/Caron.py
+++ b/caron/Caron.py
@@ -14,7 +14,7 @@ class Main:
     # ------------------------------------------------------------------
     def __init__(self):
         self.args = self.parse_args()
-        self.data = Data(buffer_safe_min=self.args.calib_frames, buffer_safe_max=self.args.buffer_safe_max, viz_target_fps=self.args.viz_fps)
+        self.data = Data(args=self.args)
         self.sim = Simulation(data=self.data,args=self.args)
         self.viz = Visualization(data=self.data,args=self.args)
 
@@ -33,6 +33,7 @@ class Main:
         parser.add_argument("--fake_injection",action="store_true",help="Inject the mock simulation at a fixed fps (does not work when --no_sim is invoked)")
         parser.add_argument("--fake_sim_fps",type=int,default=60,help="Fake simulation injection fps, when --fake_injection is invoked [Default: 60Hz]")
         parser.add_argument("--ctrl_dt", type=float, default=0.2,help="Control loop tick interval in seconds [Default: 0.2s]")
+        parser.add_argument("--verbose",action="store_true",help="Print verbose diagnostics")
         return parser.parse_args()
 
 
@@ -68,7 +69,8 @@ class Main:
                 # Wait until buffer reaches safe_min before starting viz
                 while len(self.data.buffer) < self.data.buffer_safe_min:
                     time.sleep(0.01)
-                print(f"[Main] Buffer reached size {len(self.data)}: starting visualization.")
+                if self.args.verbose:
+                    print(f"[Main] Buffer reached size {len(self.data)}: starting visualization.")
                 self.viz.run() # now start the visualization
             else:
                 raise NotImplementedError("[Main] Main.run: real simulation + visualization not implemented yet.")
@@ -78,14 +80,16 @@ class Main:
     # ----------------------------------------------------------------------
     def _control_loop(self, dt) -> None:
         """Periodically read measured SR/VR and ask Data to adjust commands."""
-        print(f"[Main] Control loop started")
+        if self.args.verbose:
+            print(f"[Main] Control loop started")
         while True and not self.viz.finished:
             time.sleep(dt) # What's a good monitoring rate?
             if self.viz.calibrated: # start monitoring only after calibration
                 sim_rate = float(self.sim.get_measured_fps())
                 viz_rate = float(self.viz.get_measured_fps())
                 self.data.balance_rates(sim_rate, viz_rate)
-                print(f"[Main] Simulation FPS:{sim_rate} | Visualization FPS: {viz_rate} | buffer={len(self.data)}")
+                if self.args.verbose:
+                    print(f"[Main] Simulation FPS:{sim_rate} | Visualization FPS: {viz_rate} | buffer={len(self.data)}")
 
 
 if __name__ == "__main__":
@@ -95,9 +99,6 @@ if __name__ == "__main__":
 
 
 """Todo:
-- What happens if the buffer is empty? The visualizer should wait for new frames.
 - Colormaps? Can they be defined also for log scale?
 - max_viz_fps obtained after calibration should override max_viz_fps in Data (still fixed at 60 Hz).
-- the average fps calculation reset should happen also when manually changing the slider
-- Implement verbose mode
 """

--- a/caron/Caron.py
+++ b/caron/Caron.py
@@ -23,7 +23,7 @@ class Main:
         parser = argparse.ArgumentParser(prog="Caron")
         parser.add_argument("--sim_size",type=int,default=512,help="Linear size of the simulation grid [Default: 512]")
         parser.add_argument("--n_frames",type=int,default=200,help="Number of simulation frames [Default: 200]")
-        parser.add_argument("--viz_fps",type=float,default=100,help="Initial visualisation FPS")
+        #parser.add_argument("--viz_fps",type=float,default=100,help="Initial visualisation FPS")
         parser.add_argument("--calib_time",type=float,default=3,help="FPS calibration time in seconds [Default: 3s]")
         parser.add_argument("--calib_frames",type=int,default=50,help="Minimum number of frames for FPS calibration [Default: 50 frames]")
         parser.add_argument("--buffer_safe_max",type=int,default=300,help="Maximum number of frames in the buffer before activating overflow [Default: 300 frames]")
@@ -100,5 +100,7 @@ if __name__ == "__main__":
 
 """Todo:
 - Colormaps? Can they be defined also for log scale?
-- max_viz_fps obtained after calibration should override max_viz_fps in Data (still fixed at 60 Hz).
+  At that point one can operate the slider, and not before.
+  Clean the parsing (initial viz_fps not used anymore).
+  Do not let anyone change the slider during calibration.
 """

--- a/caron/data.py
+++ b/caron/data.py
@@ -15,7 +15,7 @@ class Data:
     args: Namespace
     maxlen = None
     min_viz_fps: float = 1.0 # minimum allowed viz fps during balancing
-    max_viz_fps: float =80.0 # maximum allowed viz fps during balancing, in the beginning. It is updated later by the visualizer after calibration (also setting the slider maximum)
+    max_viz_fps: float =120.0 # maximum allowed viz fps during balancing, in the beginning. It is updated later by the visualizer after calibration (also setting the slider maximum)
     viz_margin:float = 5.0 # [frames] margin before pausing/resuming the simulation
     viz_margin_fps: float = 5.0  # keep viz slightly slower than sim when starving
     pillow:int = 5 # [frames] thin boundary region to avoid rapid pause/resume cycles
@@ -30,7 +30,7 @@ class Data:
         self.cond = threading.Condition(self.lock) # to notify when new frames are available
         self.buffer_safe_min=self.args.calib_frames
         self.buffer_safe_max=self.args.buffer_safe_max
-        self.viz_target_fps=self.args.viz_fps
+        self.viz_target_fps=self.max_viz_fps
 
     # Functions that act on the buffer
     # ------------------------------------------------------------------
@@ -94,13 +94,14 @@ class Data:
             n = len(self.buffer)
             if n < self.buffer_safe_min and not self.sim_finished: #Underflow: buffer too small => viz too fast overall
                 new_viz = max(self.min_viz_fps, sim_rate - self.viz_margin_fps) # can't be below one. If it doesn't recover at 1, the sim is too slow.
-                print(f"[Data] Buffer underflow detected: Visualization FPS reduced to {new_viz} Hz")
-                if sim_rate == 0.0:
-                    print("[Data] Warning: simulation was found stopped during underflow.")
-                    self._set_sim_paused_locked(False) # it really shouldn't be paused if we’re starving, but better to be safe
+                if abs(new_viz - self.viz_target_fps) > 1e-12: # don't span this action more than once because of some system numerical noise
+                    print(f"[Data] Buffer underflow detected: Visualization FPS reduced to {new_viz} Hz")
+                    if sim_rate == 0.0:
+                        print("[Data] Warning: simulation was found stopped during underflow.")
+                        self._set_sim_paused_locked(False) # it really shouldn't be paused if we’re starving, but better to be safe
 
-                self._set_viz_target_fps_locked(new_viz)
-                self.cond.notify_all()
+                    self._set_viz_target_fps_locked(new_viz)
+                    self.cond.notify_all()
                 return
 
             self.cond.notify_all()

--- a/caron/data.py
+++ b/caron/data.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from collections import deque
+from argparse import Namespace
 import numpy as np
 import threading
 
@@ -8,12 +9,11 @@ import threading
 class Data:
     """Shared buffer for frames, and handler for FPS control."""
 
+
     # Initialization
     # ------------------------------------------------------------------
-    buffer_safe_min: int
-    buffer_safe_max: int
+    args: Namespace
     maxlen = None
-    viz_target_fps: float # current target fps for the visualizer
     min_viz_fps: float = 1.0 # minimum allowed viz fps during balancing
     max_viz_fps: float = 60.0 # maximum allowed viz fps during balancing, in the beginning. It is updated later by the visualizer after calibration (also setting the slider maximum)
     viz_margin:float = 5.0 # [frames] margin before pausing/resuming the simulation
@@ -28,7 +28,9 @@ class Data:
         self.buffer = deque(maxlen=self.maxlen)
         self.lock = threading.Lock() # to protect buffer access
         self.cond = threading.Condition(self.lock) # to notify when new frames are available
-
+        self.buffer_safe_min=self.args.calib_frames
+        self.buffer_safe_max=self.args.buffer_safe_max
+        self.viz_target_fps=self.args.viz_fps
 
     # Functions that act on the buffer
     # ------------------------------------------------------------------
@@ -43,7 +45,8 @@ class Data:
         """Remove the oldest frame from the buffer (returns None if the buffer is empty)."""
         with self.cond:
             if not self.buffer:
-                print("[Data] Buffer empty.")
+                if self.args.verbose:
+                    print("[Data] Buffer empty.")
                 return None
             frame = self.buffer.popleft()
             self._apply_safe_control_sim() # Apply control logic based on new buffer size
@@ -58,11 +61,13 @@ class Data:
         n = len(self.buffer)
         # Buffer overflow: sim too fast, pause it
         if n > self.buffer_safe_max and not self.sim_paused:
-            print("[Data] Buffer overflow detected: pausing simulation.")
+            if self.args.verbose:
+                print("[Data] Buffer overflow detected: pausing simulation.")
             self._set_sim_paused_locked(True)
             self.cond.notify_all() # notify sim thread
         elif n < (self.buffer_safe_max - self.pillow) and self.sim_paused:
-            print("[Data] Buffer back to safe levels: resuming simulation.")
+            if self.args.verbose:
+                print("[Data] Buffer back to safe levels: resuming simulation.")
             self._set_sim_paused_locked(False)
 
     def wait_if_sim_paused(self, timeout: float = 0.1) -> None:

--- a/caron/data.py
+++ b/caron/data.py
@@ -15,7 +15,7 @@ class Data:
     args: Namespace
     maxlen = None
     min_viz_fps: float = 1.0 # minimum allowed viz fps during balancing
-    max_viz_fps: float = 60.0 # maximum allowed viz fps during balancing, in the beginning. It is updated later by the visualizer after calibration (also setting the slider maximum)
+    max_viz_fps: float =80.0 # maximum allowed viz fps during balancing, in the beginning. It is updated later by the visualizer after calibration (also setting the slider maximum)
     viz_margin:float = 5.0 # [frames] margin before pausing/resuming the simulation
     viz_margin_fps: float = 5.0  # keep viz slightly slower than sim when starving
     pillow:int = 5 # [frames] thin boundary region to avoid rapid pause/resume cycles

--- a/caron/simulation.py
+++ b/caron/simulation.py
@@ -30,6 +30,7 @@ class Simulation:
         self._avg_fps: float = 0.0 # current average simulation fps
         self._seen_sim_cmd_version: int = 0 # in overflow, the bump changes this value and resets the avg measurement
 
+
     # Runs
     # ----------------------------------------------------------------------
     def run(self) -> None:
@@ -41,7 +42,7 @@ class Simulation:
         self.sim_file = self.args.sim_file
         sim=np.load(self.sim_file)
         self.sim_size: int = sim.shape[1]
-        print(f"[Sim] Loaded mock simulation from {self.sim_file} with {sim.shape[2]} frames of linear size {sim[0].shape[1]}.")
+        print(f"[Sim] Loaded mock simulation from {self.sim_file} with {sim.shape[0]} frames of linear size {sim[0].shape[1]}.")
         print(f"[Sim] Simulation initialized in fake_injection mode. Injecting the buffer at {self.sim_fps} FPS.")
 
         dt = 1.0 / self.sim_fps # seconds per frame of the mock simulation injection
@@ -85,7 +86,8 @@ class Simulation:
             if (t_push - last_report_t) >= report_every_s:
                 inst_fps = (pushed - last_report_pushed) / (t_push - last_report_t) # instantaneous fps over the last interval
                 avg_fps = self.get_measured_fps() # average fps in this unpaused segment
-                print(f"[Sim] pushed={pushed}/{sim.shape[0]} | buffer={len(self.data)} | inst≈{inst_fps:.2f} Hz | avg≈{avg_fps:.2f} Hz")
+                if self.args.verbose:
+                    print(f"[Sim] pushed={pushed}/{sim.shape[0]} | buffer={len(self.data)} | inst≈{inst_fps:.2f} Hz | avg≈{avg_fps:.2f} Hz")
                 last_report_t = t_push
                 last_report_pushed = pushed
 

--- a/caron/visualization.py
+++ b/caron/visualization.py
@@ -149,6 +149,7 @@ class Visualization:
                         max_value=int(self.data.max_viz_fps),
                         callback=_fps_callback,
                         user_data=self,
+                        enabled=False, # don't allow changes until the calibration is finished
                     )
                 with dpg.group(label="Map & Keys", horizontal=True): # below there is the image and the buttons
                     dpg.add_image("frame_tag", width = self.sim_size *2, height= self.sim_size *2) # the image on the left
@@ -383,13 +384,17 @@ def _update_frame(sender, app_data, user_data: Visualization):
                     print(f"[Viz] Calibration complete: max viz FPS ≈ {measured_fps:.2f}")
                     user_data.data.max_viz_fps = measured_fps
 
-                    # Resize slider to [1, measured_max] and set it to max
+                    # Resize slider to [1, measured_max], set it to max, and enable it from now on
                     dpg.configure_item(
-                        "Caron FPS Slider",
+                        user_data.slider_tag,
                         min_value=1,
                         max_value=max_slider,
                         default_value=max_slider,
+                        enabled=True,
                     )
+                    user_data._programmatic_slider_update = True
+                    dpg.set_value(user_data.slider_tag, max_slider) # update it (need to set up an "updating" flag first)
+                    user_data._programmatic_slider_update = False
 
     # Re-register callback one (or two) dpg frame ahead
     with dpg.mutex():

--- a/caron/visualization.py
+++ b/caron/visualization.py
@@ -1,10 +1,10 @@
 import time
 import numpy as np
-from matplotlib import colormaps as cm
-import dearpygui.dearpygui as dpg
 from numba import njit
-from caron.data import Data
+from matplotlib import colormaps as cm
 import threading
+import dearpygui.dearpygui as dpg
+from caron.data import Data
 
 
 @njit
@@ -94,7 +94,8 @@ class Visualization:
         self.frames = self.data.buffer  # already a deque, as set in Data. Here it should be already populated by the full sim (no_sim) or by the injection (fake or not)
         if not self.frames: # and it would be very weird
             raise RuntimeError("[Viz] Visualization initialised with an empty buffer.")
-        print(f"[Viz] Loaded a simulation of size {self.sim_size}x{self.sim_size} with {len(self.frames)} frames as initial buffering.")
+        if self.args.verbose:
+            print(f"[Viz] Loaded a simulation of size {self.sim_size}x{self.sim_size} with {len(self.frames)} frames as initial buffering.")
 
         # Precompute first frame to initialise the texture
         frame = self.frames[0] # still works with deque, I'm already in love

--- a/caron/visualization.py
+++ b/caron/visualization.py
@@ -454,8 +454,8 @@ def _update_frame(sender, app_data, user_data: Visualization):
                     user_data._frame_period = 1.0 / user_data.fps
                     user_data._next_due_time = now + user_data._frame_period
 
-                    max_slider = max(1, int(measured_fps))
-                    print(f"[Viz] Calibration complete: max viz FPS ≈ {measured_fps:.2f}")
+                    max_slider = max(1, round(measured_fps))
+                    print(f"[Viz] Calibration complete: max viz FPS ≈ {max_slider} Hz")
                     user_data.data.max_viz_fps = measured_fps
 
                     # Resize slider to [1, measured_max], set it to max, and enable it from now on

--- a/caron/visualization.py
+++ b/caron/visualization.py
@@ -20,6 +20,13 @@ def normalize_frame(frame):
                 norm[i, j] = 1.0
     return norm
 
+@njit
+def build_log_map(alpha = 50.0): # alpha is the compression strenght. The larger the value, the higher the log compression
+    """ maps linear [0..255] -> log-compressed [0..255] """
+    x = np.linspace(0.0, 1.0, 256)
+    y = np.log1p(alpha * x) / np.log1p(alpha)
+    return (y * 255.0).astype(np.uint8)
+
 
 class Visualization:
     """
@@ -78,10 +85,29 @@ class Visualization:
         self._avg_fps: float = 0.0 # current average visualization fps
         self._seen_viz_cmd_version: int = 0 # in underflow, the bump changes this value and resets the avg measurement
 
-        # Slider
+        # LUTs for colormaps
+        self.luts = {
+            "inferno": (cm["inferno"](np.linspace(0, 1, 256))[:, :3] * 255).astype(np.uint8),
+            "viridis": (cm["viridis"](np.linspace(0, 1, 256))[:, :3] * 255).astype(np.uint8),
+            "Greys":   (cm["Greys"](np.linspace(0, 1, 256))[:, :3] * 255).astype(np.uint8),
+            "Blues":   (cm["Blues"](np.linspace(0, 1, 256))[:, :3] * 255).astype(np.uint8),
+            "Greens":  (cm["Greens"](np.linspace(0, 1, 256))[:, :3] * 255).astype(np.uint8),
+            "Oranges": (cm["Oranges"](np.linspace(0, 1, 256))[:, :3] * 255).astype(np.uint8),
+        }
+        self.cmap_names = list(self.luts.keys())
+        self.current_cmap = "inferno"
+        self.current_lut = self.luts[self.current_cmap]
+
+        # Sliders
         self._programmatic_slider_update = False # to update the slider when the fps is forced down by the buffer
         self.slider_tag = "Caron FPS Slider"
-        # DearPyGui tags
+        self.cmap_list_tag = "Caron Colormap List"
+        self.log_strength_tag = "Caron Log Strength Slider"
+        self.log_scale: bool = False
+        self.log_alpha: float = 50.0 # compression log strength
+        self.log_map = build_log_map(self.log_alpha) # basically mapping the log scale once on a 1D array
+       
+       # DearPyGui tags
         #self._font_tag: str = "big_font"
 
 
@@ -105,9 +131,6 @@ class Visualization:
         frame_rgb = np.stack((frame_norm,) * 3, axis=-1)
         frame_rgb = frame_rgb.astype(np.float32) / np.max(frame_rgb)
         self.frame_flattened: np.ndarray = frame_rgb.flatten()
-
-        # LUT for inferno colormap
-        self.inferno_lut: np.ndarray = (cm['inferno'](np.linspace(0, 1, 256))[:, :3] * 255).astype(np.uint8)
 
         # DearPyGui setup
         dpg.create_context()
@@ -152,8 +175,37 @@ class Visualization:
                         enabled=False, # don't allow changes until the calibration is finished
                     )
                 with dpg.group(label="Map & Keys", horizontal=True): # below there is the image and the buttons
-                    dpg.add_image("frame_tag", width = self.sim_size *2, height= self.sim_size *2) # the image on the left
-                    with dpg.group(label="Start&Stop"): # the buttons on the right
+                    with dpg.group(label='Colormap & Color Combo'): # image and color listbox on the left
+                        dpg.add_image("frame_tag", width = int(self.sim_size *1.9), height= int(self.sim_size *1.9)) 
+                        with dpg.group(label="", horizontal=True):
+                            dpg.add_combo(
+                                tag=self.cmap_list_tag,
+                                items=self.cmap_names,
+                                default_value=self.current_cmap,
+                                width=int(self.sim_size * 1.9),
+                                callback=_colormap_callback,
+                                user_data=self,
+                                # Optional, if your DearPyGui version supports it:
+                                # popup_height_mode=dpg.mvComboHeight_Large,
+                            )
+                            dpg.add_checkbox(
+                                label="Log",
+                                default_value=self.log_scale,
+                                callback=_log_checkbox_callback,
+                                user_data=self,
+                            )
+                        dpg.add_slider_float(
+                            tag=self.log_strength_tag,
+                            default_value=self.log_alpha,
+                            min_value=1.0,
+                            max_value=500.0,
+                            format="%.1f",
+                            callback=_log_strength_callback,
+                            user_data=self,
+                            width=int(self.sim_size * 1.9),
+                            enabled=False,
+                        )
+                    with dpg.group(label="Start & Stop"): # the buttons on the right
                         dpg.add_button( # the start button above
                             label="Start",
                             callback=_start_callback,
@@ -234,10 +286,8 @@ class Visualization:
             ver = self.data.get_viz_cmd_version()
         except Exception:
             ver = getattr(self.data, "viz_cmd_version", 0)
-
         if ver == self._seen_viz_cmd_version: # no change happened
             return
-
         self._seen_viz_cmd_version = ver # change obviously happened
         target = self.data.get_viz_target_fps() # get the needed fps as calculated by Data
         self._apply_new_fps(target, now, update_slider=True, reset_measurement=True)
@@ -250,14 +300,8 @@ class Visualization:
         self._next_due_time = now + self._frame_period # align schedule
         if reset_measurement:
             self._reset_rate_measurement(now)
-
         if update_slider and dpg.does_item_exist(self.slider_tag): 
-            cfg = dpg.get_item_configuration(self.slider_tag)
-            vmin = int(cfg.get("min_value", 1))
-            vmax = int(cfg.get("max_value", max(1, int(round(self.fps)))))
             slider_val = int(round(self.fps))
-            #slider_val = max(vmin, min(vmax, slider_val))
-
             self._programmatic_slider_update = True
             dpg.set_value(self.slider_tag, slider_val) # change the slider value as well
             self._programmatic_slider_update = False
@@ -266,6 +310,7 @@ class Visualization:
 # Callbacks (operate via user_data)
 # ----------------------------------------------------------------------
 def _start_callback(sender, app_data, user_data: Visualization):
+    "Start button"
     user_data.running = True
     now = time.perf_counter()
 
@@ -278,6 +323,7 @@ def _start_callback(sender, app_data, user_data: Visualization):
         user_data._next_due_time = now # Normal mode: align schedule so next update can happen promptly
 
 def _stop_callback(sender, app_data, user_data: Visualization):
+    "Stop button"
     user_data.running = False
     now = time.perf_counter()
     user_data._rate_on_stop(now) #stop the avg fps measurement for now
@@ -286,7 +332,7 @@ def _stop_callback(sender, app_data, user_data: Visualization):
         user_data.calib_active_start = None
 
 def _fps_callback(sender, app_data, user_data: Visualization):
-    """ app_data is the slider value """
+    """For add_slider_int, app_data is the slider value"""
     if user_data._programmatic_slider_update:
         return
     now = time.perf_counter()
@@ -294,6 +340,32 @@ def _fps_callback(sender, app_data, user_data: Visualization):
     user_data._frame_period = 1.0 / user_data.fps # new frame visualization period
     user_data._next_due_time = now + user_data._frame_period  # re-align schedule
     user_data._reset_rate_measurement(now)
+
+def _colormap_callback(sender, app_data, user_data: Visualization):
+    """For add_combo, app_data is the selected string"""
+    name = str(app_data)  # selected map
+    if name in user_data.luts:
+        user_data.current_cmap = name
+        user_data.current_lut = user_data.luts[name]
+
+def _log_checkbox_callback(sender, app_data, user_data: Visualization):
+    "Log button"
+    user_data.log_scale = bool(app_data)
+    if bool(app_data):
+        dpg.configure_item(
+            user_data.log_strength_tag,
+            enabled=True,
+                        )
+    else:
+        dpg.configure_item(
+            user_data.log_strength_tag,
+            enabled=False,
+                        )
+
+def _log_strength_callback(sender, app_data, user_data: Visualization):
+    "Log slider"
+    user_data.log_alpha = float(app_data)
+    user_data.log_map = build_log_map(user_data.log_alpha) # quick recompute (256 int)
 
 def _update_frame(sender, app_data, user_data: Visualization):
     """
@@ -340,7 +412,9 @@ def _update_frame(sender, app_data, user_data: Visualization):
             frame_norm = normalize_frame(frame)
             # Apply LUT instead of colormap
             indices = (frame_norm * 255).astype(np.uint8)
-            frame_rgb = user_data.inferno_lut[indices]
+            if user_data.log_scale:
+                indices = user_data.log_map[indices]
+            frame_rgb = user_data.current_lut[indices]
             frame_flattened = frame_rgb.flatten().astype(np.float32) / 255.0
             dpg.set_value("frame_tag", frame_flattened)
             user_data.frame_index += 1

--- a/caron/visualization.py
+++ b/caron/visualization.py
@@ -51,7 +51,7 @@ class Visualization:
 
         self.finished: bool = False
         self.running: bool = False
-        self.fps = float(self.args.viz_fps)
+        self.fps = float(self.data.max_viz_fps)
         self.max_viz_fps: float = self.fps  # after calibration will be changed to the actual max FPS
         self._frame_period = 1.0 / self.fps
         self._next_due_time = time.perf_counter()  # better clock for intervals
@@ -146,7 +146,7 @@ class Visualization:
                         height=int(self.sim_size*1),
                         default_value=int(self.fps),
                         min_value=1,
-                        max_value=int(self.fps),
+                        max_value=int(self.data.max_viz_fps),
                         callback=_fps_callback,
                         user_data=self,
                     )
@@ -381,6 +381,7 @@ def _update_frame(sender, app_data, user_data: Visualization):
 
                     max_slider = max(1, int(measured_fps))
                     print(f"[Viz] Calibration complete: max viz FPS ≈ {measured_fps:.2f}")
+                    user_data.data.max_viz_fps = measured_fps
 
                     # Resize slider to [1, measured_max] and set it to max
                     dpg.configure_item(

--- a/caron/visualization.py
+++ b/caron/visualization.py
@@ -52,6 +52,7 @@ class Visualization:
             for frame in frames_array:
                 self.data.push_frame(frame) # fill the buffer with the mock sim. It's a deque
 
+        # simulation size
         self.sim_size = self.args.sim_size
         if self.args.no_sim:
             self.sim_size: int = self.frames[0].shape[1]
@@ -62,6 +63,8 @@ class Visualization:
         self.max_viz_fps: float = self.fps  # after calibration will be changed to the actual max FPS
         self._frame_period = 1.0 / self.fps
         self._next_due_time = time.perf_counter()  # better clock for intervals
+
+        self._last_frame: np.ndarray | None = None # here we cache the last frame, in case we want to modify it while pausing (e.g. log scale)
 
         # For debugging prints only (actual time between updates)
         self.last_update_time: float = self._next_due_time
@@ -98,11 +101,12 @@ class Visualization:
         self.current_cmap = "inferno"
         self.current_lut = self.luts[self.current_cmap]
 
-        # Sliders
+        # Sliders and tags
         self._programmatic_slider_update = False # to update the slider when the fps is forced down by the buffer
         self.slider_tag = "Caron FPS Slider"
         self.cmap_list_tag = "Caron Colormap List"
         self.log_strength_tag = "Caron Log Strength Slider"
+        self.texture_tag = "frame_tag"
         self.log_scale: bool = False
         self.log_alpha: float = 50.0 # compression log strength
         self.log_map = build_log_map(self.log_alpha) # basically mapping the log scale once on a 1D array
@@ -145,7 +149,7 @@ class Visualization:
                 int(self.sim_size),
                 default_value=self.frame_flattened.tolist(),
                 format=dpg.mvFormat_Float_rgb,
-                tag="frame_tag",
+                tag=self.texture_tag,
             )
 
         # Window / layout
@@ -176,7 +180,7 @@ class Visualization:
                     )
                 with dpg.group(label="Map & Keys", horizontal=True): # below there is the image and the buttons
                     with dpg.group(label='Colormap & Color Combo'): # image and color listbox on the left
-                        dpg.add_image("frame_tag", width = int(self.sim_size *1.9), height= int(self.sim_size *1.9)) 
+                        dpg.add_image(texture_tag=self.texture_tag, width = int(self.sim_size *1.9), height= int(self.sim_size *1.9)) 
                         with dpg.group(label="", horizontal=True):
                             dpg.add_combo(
                                 tag=self.cmap_list_tag,
@@ -347,6 +351,7 @@ def _colormap_callback(sender, app_data, user_data: Visualization):
     if name in user_data.luts:
         user_data.current_cmap = name
         user_data.current_lut = user_data.luts[name]
+    _refresh_current_frame(user_data)
 
 def _log_checkbox_callback(sender, app_data, user_data: Visualization):
     "Log button"
@@ -361,11 +366,32 @@ def _log_checkbox_callback(sender, app_data, user_data: Visualization):
             user_data.log_strength_tag,
             enabled=False,
                         )
+    _refresh_current_frame(user_data)
 
 def _log_strength_callback(sender, app_data, user_data: Visualization):
     "Log slider"
     user_data.log_alpha = float(app_data)
     user_data.log_map = build_log_map(user_data.log_alpha) # quick recompute (256 int)
+    _refresh_current_frame(user_data)
+
+
+# Frame rendering and updating
+# ----------------------------------------------------------------------
+def _render_frame(user_data: Visualization, frame: np.ndarray) -> None:
+    frame_norm = normalize_frame(frame)
+    # Apply LUT instead of colormap
+    indices = (frame_norm * 255).astype(np.uint8)
+    if user_data.log_scale:
+        indices = user_data.log_map[indices]
+    frame_rgb = user_data.current_lut[indices]
+    frame_flattened = frame_rgb.reshape(-1).astype(np.float32) / 255.0
+    with dpg.mutex():
+        dpg.set_value(user_data.texture_tag, frame_flattened)
+
+def _refresh_current_frame(user_data: Visualization) -> None:
+    if user_data._last_frame is None:
+        return
+    _render_frame(user_data, user_data._last_frame)
 
 def _update_frame(sender, app_data, user_data: Visualization):
     """
@@ -409,14 +435,8 @@ def _update_frame(sender, app_data, user_data: Visualization):
             user_data.finished = True
             return
         else:
-            frame_norm = normalize_frame(frame)
-            # Apply LUT instead of colormap
-            indices = (frame_norm * 255).astype(np.uint8)
-            if user_data.log_scale:
-                indices = user_data.log_map[indices]
-            frame_rgb = user_data.current_lut[indices]
-            frame_flattened = frame_rgb.flatten().astype(np.float32) / 255.0
-            dpg.set_value("frame_tag", frame_flattened)
+            user_data._last_frame = frame # let's cache the frame just in case
+            _render_frame(user_data, frame)
             user_data.frame_index += 1
 
             t_display = time.perf_counter()


### PR DESCRIPTION
## Added a few visualization options, and a verbose mode
Add a `--verbose` option, so that all the diagnostics prints can normally be skipped.
The visualization fps is not parsed anymore. After the calibration (which runs for a few seconds at maximum velocity and can be paused, but its fps cannot be decreased), the fps is set as the maximum real fps and only from that point on it can be adjusted manually.
Added the log scale, including a slider to strengthen the log compression.
Added a colormap dropdown menu (colorbars full choice to be decided, for now I put in only six).