### PR TITLE
Preparing for simulation wire-in

### DIFF
--- a/caron/data.py
+++ b/caron/data.py
@@ -3,6 +3,7 @@ from collections import deque
 from argparse import Namespace
 import numpy as np
 import threading
+import jax.numpy as jnp
 
 
 @dataclass
@@ -23,8 +24,9 @@ class Data:
     sim_cmd_version: int = 0
     sim_paused: bool = False
     sim_finished: bool=False
-
+    
     def __post_init__(self) -> None:
+        self.coords: tuple  # to be set by simulation
         self.buffer = deque(maxlen=self.maxlen)
         self.lock = threading.Lock() # to protect buffer access
         self.cond = threading.Condition(self.lock) # to notify when new frames are available
@@ -35,7 +37,7 @@ class Data:
 
     # Functions that act on the buffer
     # ------------------------------------------------------------------
-    def push_frame(self, frame: np.ndarray) -> None:
+    def push_frame(self, frame: jnp.ndarray) -> None:
         """Add a new 2D frame to the buffer."""
         with self.cond:  # uses same lock + allows notify
             self.buffer.append(frame) # well, yeah

--- a/caron/data.py
+++ b/caron/data.py
@@ -26,7 +26,7 @@ class Data:
     sim_finished: bool=False
     
     def __post_init__(self) -> None:
-        self.coords: tuple  # to be set by simulation
+        self.coords: tuple  # spatial coordinate -- to be set by simulation
         self.buffer = deque(maxlen=self.maxlen)
         self.lock = threading.Lock() # to protect buffer access
         self.cond = threading.Condition(self.lock) # to notify when new frames are available

--- a/caron/simulation.py
+++ b/caron/simulation.py
@@ -38,6 +38,8 @@ class Simulation:
         self._avg_fps: float = 0.0 # current average simulation fps
         self._seen_sim_cmd_version: int = 0 # in overflow, the bump changes this value and resets the avg measurement
 
+        self.prim: jnp.ndarray = jnp.array([])  # will be set in import_init of by input file. Needed here because of initial push to buffer
+
         if init is None:
             self.import_init()
 
@@ -76,7 +78,7 @@ class Simulation:
             axis=0
         )
         self.data.coords = self.coords
-        self.data.push_frame(self.prim[0])  # Push initial density frame to data buffer
+        #
 
     @property
     def dx(self):
@@ -103,6 +105,7 @@ class Simulation:
         raise NotImplementedError("Simulation.run is not implemented yet.")
 
     def run_no_viz(self) -> None:
+        self.data.push_frame(self.prim)  # Push initial quantity frame to data buffer        
         self.cons = primitive_to_conserved(self.prim, self.gamma)
         self.cons = solve_euler_2d(
             U0=self.cons,
@@ -114,7 +117,6 @@ class Simulation:
             dt = self.dt,
         )
         self.prim = conserved_to_primitive(self.cons, self.gamma)
-        raise NotImplementedError("[Sim] Simulation.run is not implemented yet.")
 
     def run_mock(self) -> None:
         """Feed frames into the buffer at a fixed rate (sim_fps), and eventually get paused/unpaused."""

--- a/caron/visualization.py
+++ b/caron/visualization.py
@@ -253,6 +253,7 @@ class Visualization:
         dpg.start_dearpygui()
         dpg.destroy_context()
 
+
     # Command getters (called by Data)
     # ------------------------------------------------------------------
     def get_measured_fps(self) -> float:


### PR DESCRIPTION
## Preparing for simulation wire-in
The buffer now accepts .jnp frames explicitly
Coords is already initialized in data (albeit empty), as good practice